### PR TITLE
fix how full auth strings would not get processed correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ redisUrlParse('redis://example.com:39143/')
 
 redisUrlParse('redis://:n9y25ah7@example.com:39143/')
 //=> {host: 'example.com', port: 39143, database: '0', password: 'n9y25ah7'}
+
+redisUrlParse('redis://user:hunter2@example.com:39143/')
+//=> {host: 'example.com', port: 39143, database: '0', password: 'hunter2'}
 ```
 
 
@@ -31,8 +34,7 @@ Complete example
 
 ```
 const redisUrlParse = require('redis-url-parse')
-
-redisUrlParse(process.env.REDIS_URL)
+redisUrlParse(process.env.REDIS_URL)  // redis://
 //=> {host: 'localhost', port: 6379, database: '0', password: null}
 ```
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ module.exports = (url/*: string */)/*: RedisConfig */ => {
     host: redisConfig.hostname || 'localhost',
     port: Number(redisConfig.port || 6379),
     database: (redisConfig.pathname || '/0').substr(1) || '0',
-    password: redisConfig.auth && redisConfig.auth.substr(1)
+    password: redisConfig.auth && redisConfig.auth.split(':')[1]
   }
 }


### PR DESCRIPTION
If someone includes a username for some reason in the auth, the password would not correctly be pulled.